### PR TITLE
Exclude BibTeX files from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bib linguist-documentation


### PR DESCRIPTION
## Summary
- add `.gitattributes` file to classify `.bib` files as documentation

## Testing
- `git status --short`