### PR TITLE
Clarify README instructions on user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ pip install -r requirements.txt
 python fetch_affiliations_from_bib.py
 ```
 
-The script expects `works.bib` in the repository directory and writes `bib_authors_with_affils.csv` when done. Review the script header for settings such as the email used in API queries.
+The script expects `works.bib` in the repository directory and writes `bib_authors_with_affils.csv` when done. No API keys are required. If you want to identify yourself with a contact email, edit the `User-Agent` header at the top of the script; this email is sent with Crossref and OpenAlex requests.
 
 A sample `works.bib` file is included to provide the option to run a reproducible example – replace this file with your `works.bib ` file exported from ORCID.


### PR DESCRIPTION
## Summary
- clarify that no API keys are required
- mention editing the email in the `User-Agent` header for Crossref/OpenAlex requests

## Testing
- `git log -1 --stat`